### PR TITLE
Fix image export not saving pressure data

### DIFF
--- a/Rendering/StrokeRenderer.cs
+++ b/Rendering/StrokeRenderer.cs
@@ -149,11 +149,11 @@ namespace ShakyDoodle.Rendering
         {
             if (!stroke.Shake) shakeIntensity = 0;
 
-            var pen = new Pen(overrideColor, _brushHelper.GetStrokeSize(stroke));
-            pen.LineCap = stroke.PenLineCap;
-
             for (int i = 1; i < stroke.Points.Count; i++)
             {
+                var pen = _brushHelper.ChooseBrushSettings(stroke, overrideColor, i < stroke.Pressures.Count ? stroke.Pressures[i] : 1f);
+                pen.LineCap = stroke.PenLineCap;
+
                 var p1 = _shakeController.GetShakenPoint(stroke.Points[i - 1], shakeIntensity);
                 var p2 = _shakeController.GetShakenPoint(stroke.Points[i], shakeIntensity);
                 context.DrawLine(pen, p1, p2);

--- a/Utils/BrushHelper.cs
+++ b/Utils/BrushHelper.cs
@@ -20,6 +20,22 @@ namespace ShakyDoodle.Utils
             return newPen;
         }
 
+        public Pen ChooseBrushSettings(Stroke stroke, IBrush overrideColor, float rawPressure)
+        {
+            var size = GetStrokeSize(stroke);
+
+            double scaledPressure = Math.Min(rawPressure * 2, 1);
+            SolidColorBrush targetBrush;
+
+            if (overrideColor is SolidColorBrush colorBrush)
+            {
+                targetBrush = new SolidColorBrush(colorBrush.Color, stroke.Alpha * scaledPressure);
+            }
+            else throw new NotImplementedException("Impossible to extract brush type");
+
+            return new Pen(targetBrush, size * rawPressure);
+        }
+
         public Pen ChooseBrushSettings(Stroke stroke, double scaledPressure, double rawPressure)
         {
             var color = _colorHelper.GetAvaloniaColor(stroke.Color);


### PR DESCRIPTION
I'm considering that the brush used in DrawStrokeWithColorOverride is always a SolidColorBrush, if it's not the case the code below will need to be changed